### PR TITLE
Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: cpp
 services:
     - docker
 
-before_install:
-    - docker build .
-
 script:
+    - docker build .
     - docker run -d -p 127.0.0.1:80:4567 chemiskyy/smartplus-stack

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: cpp
+
+services:
+    - docker
+
+before_install:
+    - docker build .
+
+script:
+    - docker run -d -p 127.0.0.1:80:4567 chemiskyy/smartplus-stack

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ smartplus
 
 
 [![GitHub license](https://img.shields.io/badge/licence-GPL%203-blue.svg)](https://github.com/smartplus-team/smartplus/blob/master/LICENSE.txt)
+[![Build Status](https://travis-ci.org/abetlen/smartplus.svg?branch=master)](https://travis-ci.org/abetlen/smartplus)
 
 About
 -----


### PR DESCRIPTION
Tests builds using TravisCI and a docker image. After merging go to [travis-ci.org](https://travis-ci.org/), sign-up using github, and enable smartplus. The shield url will also need to be updated just because it currently points to my fork and not the main repo.
